### PR TITLE
2 rm quotes via user context menu

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -132,6 +132,32 @@ app.on(Events.InteractionCreate, async (interaction) => {
     }
 });
 
+// app user context menu event
+app.on(Events.InteractionCreate, async (interaction) => {
+    if (!interaction.isUserContextMenuCommand()) return;
+
+    const context = interaction.client.contexts.get(interaction.commandName);
+
+    if (!context) {
+        logger.error(`No context matching ${interaction.commandName} was found.`);
+        return;
+    }
+
+    try {
+        await context.execute(interaction);
+    } catch (error) {
+        logger.error(error);
+
+        if (interaction.replied || interaction.deferred) {
+            await interaction.followUp('There was an error while executing this contexts menu command.');
+            await interaction.guild.channels.cache.get(chan).send(`<@${admin}> Error Report:\n\`\`\`${error}\`\`\``);
+        } else {
+            await interaction.reply('There was an error while executing this context menu command.');
+            await interaction.guild.channels.cache.get(chan).send(`<@${admin}> Error Report:\n\`\`\`${error}\`\`\``);
+        }
+    }
+});
+
 // app chat command event
 app.on(Events.InteractionCreate, async (interaction) => {
     if (!interaction.isChatInputCommand()) return;

--- a/src/bot/interactions/menus/message/quotemessage.js
+++ b/src/bot/interactions/menus/message/quotemessage.js
@@ -10,7 +10,8 @@ module.exports = {
         const message = interaction.targetMessage;
         const content = message.content.toString();
         const id = message.author.id;
-        const author = interaction.guild.members.cache.get(id).nickname;
+        const member = interaction.guild.members.cache.get(id);
+        const author = member.nickname || member.displayName;
         const channel = await interaction.guild.channels.cache.get(quotesChannel);
 
         if (message.author === interaction.client.user) {

--- a/src/bot/interactions/menus/user/quoteuser.js
+++ b/src/bot/interactions/menus/user/quoteuser.js
@@ -1,32 +1,40 @@
 require('dotenv').config({ path: '../src/configs/.env' });
 const { ContextMenuCommandBuilder, ApplicationCommandType, EmbedBuilder, MessageFlags } = require('discord.js');
+const { customQuoteModal } = require('../../modals/addUserQuote');
 const quotesChannel = process.env.dandy_quotes_chan_id;
 
 module.exports = {
     data: new ContextMenuCommandBuilder()
-        .setName('Quote Message')
+        .setName('Quote User')
         .setType(ApplicationCommandType.User),
     async execute(interaction) {
         const targetUser = interaction.targetUser;
-        const channel = await interaction.guild.channels.cache.get(quotesChannel);
+        const id = targetUser.id;
+        const member = interaction.guild.members.cache.get(id);
+        const nick = member.nickname || member.displayName;
+        const channel = interaction.guild.channels.cache.get(quotesChannel);
 
         if (targetUser === interaction.client.user) {
             interaction.reply({ content: "Sorry! I am simply too powerful to be quoted!", flags: MessageFlags.Ephemeral });
             return;
         }
 
-        const quoteEmbed = new EmbedBuilder()
-            .setColor(0x0099FF)
-            .setDescription(`${content}`)
-            .setTimestamp()
-            .setFooter({ text: `${author}` });
+        customQuoteModal(interaction, nick);
 
-        try {
-            await channel.send({ embeds: [ quoteEmbed ] });
-            await interaction.reply({ content: "The message you selected has been sent to the quotes channel!", flags: MessageFlags.Ephemeral });
-        }
-        catch (e) {
-            throw new Error(e);
-        }
+        const filter = (interaction) => interaction.customId === 'addUserQuote';
+        interaction.awaitModalSubmit({ filter, time: 15_000 })
+        .then((interaction) => {
+            const response = interaction.fields.getTextInputValue('content');
+
+            const quoteEmbed = new EmbedBuilder()
+                .setColor(0x0099FF)
+                .setDescription(`${response}`)
+                .setTimestamp()
+                .setFooter({ text: `${nick}` });
+            
+            channel.send({ embeds: [ quoteEmbed ] });
+            interaction.reply({ content: "Sent to the quote channel!", flags: MessageFlags.Ephemeral });
+        })
+        .catch(e => console.log(e));
     }
 }

--- a/src/bot/interactions/menus/user/quoteuser.js
+++ b/src/bot/interactions/menus/user/quoteuser.js
@@ -1,0 +1,32 @@
+require('dotenv').config({ path: '../src/configs/.env' });
+const { ContextMenuCommandBuilder, ApplicationCommandType, EmbedBuilder, MessageFlags } = require('discord.js');
+const quotesChannel = process.env.dandy_quotes_chan_id;
+
+module.exports = {
+    data: new ContextMenuCommandBuilder()
+        .setName('Quote Message')
+        .setType(ApplicationCommandType.User),
+    async execute(interaction) {
+        const targetUser = interaction.targetUser;
+        const channel = await interaction.guild.channels.cache.get(quotesChannel);
+
+        if (targetUser === interaction.client.user) {
+            interaction.reply({ content: "Sorry! I am simply too powerful to be quoted!", flags: MessageFlags.Ephemeral });
+            return;
+        }
+
+        const quoteEmbed = new EmbedBuilder()
+            .setColor(0x0099FF)
+            .setDescription(`${content}`)
+            .setTimestamp()
+            .setFooter({ text: `${author}` });
+
+        try {
+            await channel.send({ embeds: [ quoteEmbed ] });
+            await interaction.reply({ content: "The message you selected has been sent to the quotes channel!", flags: MessageFlags.Ephemeral });
+        }
+        catch (e) {
+            throw new Error(e);
+        }
+    }
+}

--- a/src/bot/interactions/modals/addUserQuote.js
+++ b/src/bot/interactions/modals/addUserQuote.js
@@ -1,0 +1,23 @@
+const { ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle } = require('discord.js');
+
+const quoteModal = new ModalBuilder()
+    .setCustomId('addUserQuote')
+    .setTitle('Add user quote.')
+
+const quoteContent = new TextInputBuilder()
+    .setCustomId('content')
+    .setLabel('What did they say?? :eyes:')
+    .setStyle(TextInputStyle.Paragraph);
+
+const actionRow = new ActionRowBuilder().addComponents(quoteContent);
+
+quoteModal.addComponents(actionRow);
+
+const customQuoteModal = async (interaction, name) => {
+    quoteModal.setTitle(`Add a quote from ${name}!`);
+    quoteContent.setLabel(`What did ${name} say?? :eyes:`);
+    
+    return await interaction.showModal(quoteModal);
+}
+
+module.exports = { customQuoteModal };


### PR DESCRIPTION
1. Added a user context menu that allows you to directly select a user and trigger a modal so that you can manually enter the content you would like to quote, for instances such as quotable moments in VC.
2. Fixed an small error in the quote message context menu code that could potentially return a user's name as null if they did not have a server nickname set.